### PR TITLE
Make config file compatible with FindSQLite3 provided by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 project(sqlite3
-    VERSION 3
+    VERSION 3.31.1
     LANGUAGES C
     )
 
@@ -94,24 +94,25 @@ if (BUILD_RECOMMENDED_OPTS)
         )
 endif()
 target_include_directories(${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
-set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER sqlite3.h)
-make_target_build_options(${PROJECT_NAME})
-add_library(sqlite3::sqlite3 ALIAS ${PROJECT_NAME})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    OUTPUT_NAME sqlite3
+    PUBLIC_HEADER sqlite3.h
+    DEBUG_POSTFIX d
+    )
 
-install(TARGETS ${PROJECT_NAME} EXPORT Sqlite3Config
+install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}Config
     ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
     PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sqlite3
     )
-install(EXPORT Sqlite3Config
-    NAMESPACE sqlite3::
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
+install(EXPORT ${PROJECT_NAME}Config
+    NAMESPACE SQLite::
+    DESTINATION cmake
     )
-export(TARGETS ${PROJECT_NAME} FILE Sqlite3Config.cmake)
 
 if (BUILD_SHELL)
     add_executable(sqlite3_shell shell.c)
     set_target_properties(sqlite3_shell PROPERTIES OUTPUT_NAME sqlite3)
-    target_link_libraries(sqlite3_shell PRIVATE sqlite3::sqlite3)
+    target_link_libraries(sqlite3_shell PRIVATE sqlite3)
     install(TARGETS sqlite3_shell RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ $> make install
 ```
 
 ## usage
-to integrate this library into your project simply add these lines to your
+to integrate this library into your project simply add these lines to your project
 `cmake`:
 ```cmake
-find_package(Sqlite3)
-target_link_libraries(${PROJECT_NAME} sqlite3::sqlite3)
+find_package(SQLite3 CONFIG)
+target_link_libraries(${PROJECT_NAME} SQLite::SQLite3)
 ```
 
 the include directory and link library will be automatically added to your target.
-
+If you need to switch your project to use "standard" sqlite remove CONFIG option
+in find_package function call.
 
 ## SQLite3 build options
 `SQLite` comes with plenty of


### PR DESCRIPTION
* Rename namespace to SQLite and project to SQLite3 as FindSQLite3 requires
* Provide the version of SQLite (should be updated for each amalgamation update)
* Provide binary output name to be the same as before sqlite3
* Fix name and destination path for config file according to https://cmake.org/cmake/help/latest/command/find_package.html#search-procedure
* Remove redundant manual copy of config file
* Remove redundant call of undocumented function make_target_build_option
* Remove redundant local alias project
* Documentation how to use updated to reflect these changes